### PR TITLE
Revise seed to generate reviews that are either over/under 50 word count

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "build": "webpack",
     "dev-start": "nodemon server/index.js",
-    "seed": "node db/seed.js"
+    "seed": "node server/db/seed.js"
   },
   "repository": {
     "type": "git",

--- a/server/db/seed.js
+++ b/server/db/seed.js
@@ -42,10 +42,14 @@ for (let i = 0; i < 100; i += 1) {
 
     // generate data for review object
     const created_at = faker.date.past();
-    const text = faker.lorem.paragraph();
+    const textShort = faker.lorem.paragraph();
+    const textLong = faker.lorem.paragraphs();
     const username = faker.name.firstName();
     const avatar = faker.internet.avatar();
     const response_text = faker.lorem.sentence();
+
+    // random number to determin if this review has text longer than 50 words
+    const random_reviewLength = faker.random.number({ min: 0, max: 100 });
 
     // random number to determine if this review has a response
     const random_hasResponse = faker.random.number({ min: 0, max: 100 });
@@ -55,7 +59,7 @@ for (let i = 0; i < 100; i += 1) {
     // if not, the review object will NOT have a response
     if (random_hasResponse % 3 === 0) {
       review.created_at = created_at;
-      review.text = text;
+      review.text = random_reviewLength % 2 === 0 ? textShort : textLong;
       review.username = username;
       review.avatar = avatar;
       review.response_username = response_username;
@@ -63,7 +67,7 @@ for (let i = 0; i < 100; i += 1) {
       review.response_text = response_text;
     } else {
       review.created_at = created_at;
-      review.text = text;
+      review.text = random_reviewLength % 2 === 0 ? textShort : textLong;
       review.username = username;
       review.avatar = avatar;
     }


### PR DESCRIPTION
Trello ticket: https://trello.com/c/89YubWxN/23-revise-seed-so-that-some-reviews-randomly-chosen-are-longer-than-50-words-long

By default, reviews only show the first 50 words. If the actual review text is longer than 50 words, a user can click a "read more" link to show the entirety of the review. I need the seed to generate some reviews that are under 50 words long and other reviews that are over 50 words long to demonstrate the "read more" feature.